### PR TITLE
Add prettier check to format non-python code

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,3 +46,9 @@ repos:
   rev: 0.28.0
   hooks:
     - id: check-github-workflows
+
+- repo: https://github.com/pre-commit/mirrors-prettier
+  rev: "v3.1.0"
+  hooks:
+    - id: prettier
+      types_or: [yaml, markdown, html, css, scss, javascript, json]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,54 +1,49 @@
 # Integration with GitHub Actions
 # See https://pre-commit.ci/
 ci:
-    autofix_prs: false
-    autoupdate_schedule: weekly
-    autofix_commit_msg: |
-        :rotating_light: [pre-commit.ci] auto fixes from pre-commit.com hooks
+  autofix_prs: false
+  autoupdate_schedule: weekly
+  autofix_commit_msg: |
+    :rotating_light: [pre-commit.ci] auto fixes from pre-commit.com hooks
 
-        for more information, see https://pre-commit.ci
-    autoupdate_commit_msg: ':arrow_up: [pre-commit.ci] pre-commit autoupdate'
+    for more information, see https://pre-commit.ci
+  autoupdate_commit_msg: ":arrow_up: [pre-commit.ci] pre-commit autoupdate"
 
 repos:
-- repo: https://github.com/psf/black
-  rev: 24.2.0
-  hooks:
-  - id: black
+  - repo: https://github.com/psf/black
+    rev: 24.2.0
+    hooks:
+      - id: black
 
-- repo: https://github.com/pycqa/isort
-  rev: 5.13.2
-  hooks:
-  - id: isort
+  - repo: https://github.com/pycqa/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
 
-- repo: https://github.com/codespell-project/codespell
-  rev: v2.2.6
-  hooks:
-  - id: codespell
-    args: [
-      "doc examples examples_trame pyvista tests",
-      "*.py *.rst *.md",
-    ]
-    additional_dependencies: [
-      "tomli"
-    ]
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.2.6
+    hooks:
+      - id: codespell
+        args: ["doc examples examples_trame pyvista tests", "*.py *.rst *.md"]
+        additional_dependencies: ["tomli"]
 
-- repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.5.0
-  hooks:
-  - id: check-merge-conflict
-  - id: debug-statements
-  - id: no-commit-to-branch
-    args: [--branch, main]
-  - id: requirements-txt-fixer
-  - id: trailing-whitespace
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: check-merge-conflict
+      - id: debug-statements
+      - id: no-commit-to-branch
+        args: [--branch, main]
+      - id: requirements-txt-fixer
+      - id: trailing-whitespace
 
-- repo: https://github.com/python-jsonschema/check-jsonschema
-  rev: 0.28.0
-  hooks:
-    - id: check-github-workflows
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 0.28.0
+    hooks:
+      - id: check-github-workflows
 
-- repo: https://github.com/pre-commit/mirrors-prettier
-  rev: "v3.1.0"
-  hooks:
-    - id: prettier
-      types_or: [yaml, markdown, html, css, scss, javascript, json]
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: "v3.1.0"
+    hooks:
+      - id: prettier
+        types_or: [yaml, markdown, html, css, scss, javascript, json]

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -17,23 +17,23 @@ diverse, inclusive, and healthy community.
 Examples of behavior that contributes to a positive environment for our
 community include:
 
-* Demonstrating empathy and kindness toward other people
-* Being respectful of differing opinions, viewpoints, and experiences
-* Giving and gracefully accepting constructive feedback
-* Accepting responsibility and apologizing to those affected by our mistakes,
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
   and learning from the experience
-* Focusing on what is best not just for us as individuals, but for the
+- Focusing on what is best not just for us as individuals, but for the
   overall community
 
 Examples of unacceptable behavior include:
 
-* The use of sexualized language or imagery, and sexual attention or
+- The use of sexualized language or imagery, and sexual attention or
   advances of any kind
-* Trolling, insulting or derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or email
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email
   address, without their explicit permission
-* Other conduct which could reasonably be considered inappropriate in a
+- Other conduct which could reasonably be considered inappropriate in a
   professional setting
 
 ## Enforcement Responsibilities
@@ -106,7 +106,7 @@ Violating these terms may lead to a permanent ban.
 ### 4. Permanent Ban
 
 **Community Impact**: Demonstrating a pattern of violation of community
-standards, including sustained inappropriate behavior,  harassment of an
+standards, including sustained inappropriate behavior, harassment of an
 individual, or aggression toward or disparagement of classes of individuals.
 
 **Consequence**: A permanent ban from any sort of public interaction within


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
The [prettier](https://prettier.io/) tool can format a large number of different file types. Scientific Python Library Development Guide recommends using prettier to format non-python code.

<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->


### Details

- https://learn.scientific-python.org/development/guides/style/#prettier
